### PR TITLE
Add option to save and read local copy of spec object

### DIFF
--- a/redfish_prompt/cli.py
+++ b/redfish_prompt/cli.py
@@ -30,7 +30,8 @@ from .lexer import HttpPromptLexer
 from .utils import smart_quote
 from .xdg import get_data_dir
 
-
+import pickle
+ 
 # XXX: http://click.pocoo.org/python3/#unicode-literals
 click.disable_unicode_literals_warning = True
 
@@ -90,10 +91,12 @@ def normalize_url(ctx, param, value):
               callback=normalize_url)
 @click.option('--env', help="Environment file to preload.",
               type=click.Path(exists=True))
+@click.option('--savespec', help="Save local copy of OpenAPI/Swagger specification file.",
+              is_flag=True, default=False)
 @click.argument('url', default='')
 @click.argument('http_options', nargs=-1, type=click.UNPROCESSED)
 @click.version_option(message='%(version)s')
-def cli(spec, env, url, http_options):
+def cli(spec, env, url, http_options, savespec):
     click.echo('Version: %s' % __version__)
 
     copied, config_path = config.initialize()
@@ -136,6 +139,12 @@ def cli(spec, env, url, http_options):
             spec = None
         finally:
             f.close()
+
+    if savespec:
+        savedspec=os.path.join(get_data_dir(), 'savedspec')
+        click.echo("Saving local copy of the OpenAPI specification as {0}".format(savedspec))
+        with open(savedspec, 'wb') as handle:
+            pickle.dump(spec, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
     if url:
         url = fix_incomplete_url(url)


### PR DESCRIPTION
Add --savespec command line option to allow saving of the externally provided specification if present, using Python pickle, and read this saved pickled object in by default if it is present. The location of the saved object is echoed for easy reference. Removing this saved file from the given location will cause redfish-prompt to reload the default specification on next execution, or any other externally supplied spec, which can once again be saved to a local pbject using the --savespec flag.